### PR TITLE
Changed renaming file as configurable and optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,5 @@ Notedown supports these settings:
 - **markdown_extension**: The file extension used when creating new notes. This should not include a leading period (`.`). If not defined, `md` is used. Example: `"markdown_extension": "markdown"`.
 
 - **note_folder_patterns**: Defines which folders contain *notes* compatible with Notedown. The folder patterns (which may use wildcards compatible with [fnmatch](https://docs.python.org/3/library/fnmatch.html#fnmatch.fnmatch)) are matched against the name of a Markdown file's containing folder to determine if the file should be considered a note. If not defined or an empty list, then all Markdown files are considered to be notes. Example: `"note_folder_patterns": ["Notes"]`.
+
+- **reflect_title_in_filename**: Whether to propose a new file name that will reflect title found in the note text. If not defined or `true` then synchronization of filename to title is enabled. Example: `"reflect_title_in_filename": false`.

--- a/notedown.py
+++ b/notedown.py
@@ -198,7 +198,11 @@ class NotedownEventListener(sublime_plugin.EventListener):
         if not _viewing_a_note(view):
             return
 
-        renamed = self._reflect_title_in_filename(view)
+        reflect_title_in_filename = _setting('reflect_title_in_filename', bool)
+        renamed = False
+        if reflect_title_in_filename:
+            renamed = self._reflect_title_in_filename(view)
+
         if not renamed:
             view.run_command('notedown_lint')
 


### PR DESCRIPTION
Rename file to reflect title from the note content is now optional and can be configured via user settings.